### PR TITLE
Fix disconnect during OTA by spacing out erases

### DIFF
--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -489,12 +489,12 @@ static int g_imgr_sector_id = -1;
 static uint32_t g_imgr_sector_end = 0;
 
 /**
- * Erases a flash sector as image upload crosses a sector boundary
- * Erasing the entire flash size at one time can take significant time 
- * causing a bluetooth disconnect or significant battery sag.
+ * Erases a flash sector as image upload crosses a sector boundary.
+ * Erasing the entire flash size at one time can take significant time,
+ *   causing a bluetooth disconnect or significant battery sag.
  * Instead we will erase immediately prior to crossing a sector.
  * We could check for empty to increase efficiency, but instead we always erase
- * for consistency and simplicity
+ *   for consistency and simplicity.
  *
  * @param fa       Flash area being traversed
  * @param off      Offset that is about to be written
@@ -783,11 +783,6 @@ imgr_upload(struct mgmt_cbuf *cb)
 #endif
 
 #ifndef LAZY_FLASH_ERASE
-        /*
-         * erasing the entire req.size at one time can take significant time 
-         * causing a bluetooth disconnect or significant battery sag
-         * instead of erasing here we will erase a sector at a time as we go
-         */
         if (action.erase) {
             rc = flash_area_erase(fa, 0, req.size);
             if (rc != 0) {
@@ -810,16 +805,13 @@ imgr_upload(struct mgmt_cbuf *cb)
         if (flash_area_write(fa, req.off, req.img_data, action.write_bytes) != 0) {
             rc = MGMT_ERR_EUNKNOWN;
             errstr = imgmgr_err_str_flash_write_failed;
-        }
-#ifdef LAZY_FLASH_ERASE
-        else {
+        } else {
             imgr_state.off += action.write_bytes;
             if (imgr_state.off == imgr_state.size) {
                 /* Done */
                 imgr_state.area_id = -1;
             }
         }
-#endif
     }
 
     flash_area_close(fa);

--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -32,6 +32,11 @@ syscfg.defs:
             The maximum amount of image or core data that can fit in a
             single NMP message
         value: 512
+    IMGMGR_LAZY_ERASE:
+        description: >
+            During a firmware upgrade, erase flash a sector at a time
+            prior to writing to it, rather than all at once at start
+        value: 1
     IMGMGR_VERBOSE_ERR:
         description: >
             Send verbose error message in responses.


### PR DESCRIPTION
Erasing the entire flash image size at one time can take significant time

causing a bluetooth disconnect or significant battery sag.
Instead, we erase immediately prior to crossing a sector while writing the image.

We could check for empty to increase efficiency.
However, for simplicity and consistency we will always erase lazily.