### PR TITLE
Add sycfg to set idle stack size

### DIFF
--- a/hw/mcu/dialog/cmac/include/cmac/arch/cortex_m0_cmac/os/os_arch.h
+++ b/hw/mcu/dialog/cmac/include/cmac/arch/cortex_m0_cmac/os/os_arch.h
@@ -39,9 +39,9 @@ typedef uint32_t os_stack_t;
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
 #if MYNEWT_VAL(OS_SYSVIEW)
-#define OS_IDLE_STACK_SIZE (80)
+#define OS_IDLE_STACK_SIZE ((MYNEWT_VAL(OS_IDLE_STACK_SZ)) + 16)
 #else
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 #endif
 
 static inline int

--- a/kernel/os/include/os/arch/arc/os/os_arch.h
+++ b/kernel/os/include/os/arch/arc/os/os_arch.h
@@ -35,8 +35,7 @@ typedef uint32_t os_stack_t;
 
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
-#define OS_IDLE_STACK_SIZE (64)
-
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"
 

--- a/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
@@ -38,9 +38,9 @@ typedef uint32_t os_stack_t;
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
 #if MYNEWT_VAL(OS_SYSVIEW)
-#define OS_IDLE_STACK_SIZE (80)
+#define OS_IDLE_STACK_SIZE ((MYNEWT_VAL(OS_IDLE_STACK_SZ)) + 16)
 #else
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 #endif
 
 static inline int

--- a/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
@@ -38,9 +38,9 @@ typedef uint32_t os_stack_t;
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
 #if MYNEWT_VAL(OS_SYSVIEW)
-#define OS_IDLE_STACK_SIZE (80)
+#define OS_IDLE_STACK_SIZE ((MYNEWT_VAL(OS_IDLE_STACK_SZ)) + 16)
 #else
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 #endif
 
 static inline int

--- a/kernel/os/include/os/arch/cortex_m33/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m33/os/os_arch.h
@@ -38,9 +38,9 @@ typedef uint32_t os_stack_t;
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
 #if MYNEWT_VAL(OS_SYSVIEW)
-#define OS_IDLE_STACK_SIZE (80)
+#define OS_IDLE_STACK_SIZE ((MYNEWT_VAL(OS_IDLE_STACK_SZ)) + 16)
 #else
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 #endif
 
 static inline int

--- a/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
@@ -38,9 +38,9 @@ typedef uint32_t os_stack_t;
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
 #if MYNEWT_VAL(OS_SYSVIEW)
-#define OS_IDLE_STACK_SIZE (80)
+#define OS_IDLE_STACK_SIZE ((MYNEWT_VAL(OS_IDLE_STACK_SZ)) + 16)
 #else
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 #endif
 
 static inline int

--- a/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
@@ -38,9 +38,9 @@ typedef uint32_t os_stack_t;
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
 #if MYNEWT_VAL(OS_SYSVIEW)
-#define OS_IDLE_STACK_SIZE (80)
+#define OS_IDLE_STACK_SIZE ((MYNEWT_VAL(OS_IDLE_STACK_SZ)) + 16)
 #else
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 #endif
 
 static inline int

--- a/kernel/os/include/os/arch/mips/os/os_arch.h
+++ b/kernel/os/include/os/arch/mips/os/os_arch.h
@@ -36,7 +36,7 @@ typedef uint32_t os_stack_t;
 
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 
 #define OS_ENTER_CRITICAL(__os_sr)          \
         do {                                \

--- a/kernel/os/include/os/arch/rv32imac/os/os_arch.h
+++ b/kernel/os/include/os/arch/rv32imac/os/os_arch.h
@@ -35,7 +35,7 @@ typedef uint32_t os_stack_t;
 
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (96)
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (MYNEWT_VAL(OS_IDLE_STACK_SZ))
 
 void plic_default_isr(int num);
 

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -24,6 +24,9 @@ syscfg.defs:
     OS_MAIN_STACK_SIZE:
         description: 'Stack size of initialization and main task'
         value: 1024
+    OS_IDLE_STACK_SZ:
+        description: 'Stack size of idle task'
+        value: 64
     OS_CLI:
         description: 'CLI commands to inspect OS'
         value: 0


### PR DESCRIPTION
In some condition the Idle stack size of 64 seems too small. Add the possibility for the app to set a custom idle stack size